### PR TITLE
Fixed params encoding

### DIFF
--- a/src/Shoplo/Resource.php
+++ b/src/Shoplo/Resource.php
@@ -17,7 +17,7 @@ class Resource
 	{
 		$string = '';
 		if (is_array($params)) {
-			foreach ($params as $k => $v) if (!is_array($v)) $string .= $k . '=' . urlencode($v) . '&';
+			foreach ($params as $k => $v) if (!is_array($v)) $string .= $k . '=' . rawurlencode($v) . '&';
 			$string = substr($string, 0, strlen($string) - 1);
 		}
 		return $string;


### PR DESCRIPTION
Wrong encoding cause exception "Signature verification failed (HMAC-SHA1)" for parameters which contain space character (e.g. 2016-10-25 10:19:50). With rawurlencode it works properly.
